### PR TITLE
Add more extensive error handling for tag-delete

### DIFF
--- a/src/main/java/seedu/address/logic/Messages.java
+++ b/src/main/java/seedu/address/logic/Messages.java
@@ -79,6 +79,13 @@ public class Messages {
     }
 
     /**
+     * Formats the {@code tags} to display the set of tags in the appropriate format.
+     */
+    public static String tagSetToString(Set<Tag> tags) {
+        return tags.stream().map(Tag::getTagName).collect(Collectors.joining(", "));
+    }
+
+    /**
      * Formats the {@code person} to display their tags.
      */
     public static String getName(Person person) {

--- a/src/main/java/seedu/address/logic/commands/TagDeleteCommand.java
+++ b/src/main/java/seedu/address/logic/commands/TagDeleteCommand.java
@@ -119,6 +119,7 @@ public class TagDeleteCommand extends Command {
                 return tagsNotExist + tagsExist;
             }
         }
-        return String.format(MESSAGE_DELETE_TAG_SUCCESS, tagsToDelete, Messages.format(editedPerson));
+        return String.format(MESSAGE_DELETE_TAG_SUCCESS, Messages.tagSetToString(tagsToDelete),
+                Messages.format(editedPerson));
     }
 }

--- a/src/test/java/seedu/address/logic/commands/CommandTestUtil.java
+++ b/src/test/java/seedu/address/logic/commands/CommandTestUtil.java
@@ -30,6 +30,7 @@ public class CommandTestUtil {
     public static final String VALID_NAME_AMY = "Amy Bee";
     public static final String VALID_NAME_BOB = "Bob Choo";
     public static final String VALID_NAME_GEORGE = "George Best";
+    public static final String VALID_NAME_ALICE = "Alice Pauline";
     public static final String VALID_PHONE_AMY = "11111111";
     public static final String VALID_PHONE_BOB = "22222222";
     public static final String VALID_EMAIL_AMY = "amy@example.com";
@@ -40,6 +41,7 @@ public class CommandTestUtil {
     public static final String VALID_JOB_BOB = "Photographer";
     public static final String VALID_TAG_HUSBAND = "husband";
     public static final String VALID_TAG_FRIEND = "friend 25";
+    public static final String VALID_TAG_FRIENDS = "friends";
     public static final String VALID_TAG_AMY = "Jane and Tom 230412";
     public static final String VALID_TAG_BOB = "Jim and Joe 240101";
 

--- a/src/test/java/seedu/address/logic/commands/CommandTestUtil.java
+++ b/src/test/java/seedu/address/logic/commands/CommandTestUtil.java
@@ -31,6 +31,7 @@ public class CommandTestUtil {
     public static final String VALID_NAME_BOB = "Bob Choo";
     public static final String VALID_NAME_GEORGE = "George Best";
     public static final String VALID_NAME_ALICE = "Alice Pauline";
+    public static final String VALID_NAME_BENSON = "Benson Meier";
     public static final String VALID_PHONE_AMY = "11111111";
     public static final String VALID_PHONE_BOB = "22222222";
     public static final String VALID_EMAIL_AMY = "amy@example.com";
@@ -39,11 +40,12 @@ public class CommandTestUtil {
     public static final String VALID_ADDRESS_BOB = "Block 123, Bobby Street 3";
     public static final String VALID_JOB_AMY = "Caterer";
     public static final String VALID_JOB_BOB = "Photographer";
-    public static final String VALID_TAG_HUSBAND = "husband";
     public static final String VALID_TAG_FRIEND = "friend 25";
     public static final String VALID_TAG_FRIENDS = "friends";
     public static final String VALID_TAG_AMY = "Jane and Tom 230412";
     public static final String VALID_TAG_BOB = "Jim and Joe 240101";
+    public static final String VALID_TAG_HUSBAND = "husband";
+    public static final String VALID_TAG_OWESMONEY = "owesMoney";
 
     public static final String NAME_DESC_AMY = " " + PREFIX_NAME + VALID_NAME_AMY;
     public static final String NAME_DESC_BOB = " " + PREFIX_NAME + VALID_NAME_BOB;

--- a/src/test/java/seedu/address/logic/commands/TagDeleteCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/TagDeleteCommandTest.java
@@ -2,11 +2,11 @@ package seedu.address.logic.commands;
 
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
+import static seedu.address.logic.commands.CommandTestUtil.VALID_NAME_ALICE;
 import static seedu.address.logic.commands.CommandTestUtil.VALID_NAME_AMY;
-import static seedu.address.logic.commands.CommandTestUtil.VALID_NAME_GEORGE;
 import static seedu.address.logic.commands.CommandTestUtil.VALID_TAG_AMY;
 import static seedu.address.logic.commands.CommandTestUtil.VALID_TAG_BOB;
-import static seedu.address.logic.commands.CommandTestUtil.VALID_TAG_FRIEND;
+import static seedu.address.logic.commands.CommandTestUtil.VALID_TAG_FRIENDS;
 import static seedu.address.logic.commands.CommandTestUtil.assertCommandSuccess;
 import static seedu.address.testutil.TypicalPersons.getTypicalAddressBook;
 
@@ -33,18 +33,18 @@ public class TagDeleteCommandTest {
     @Test
     public void execute_deleteTagUnfilteredList_success() {
         List<Person> matchingPersons = model.getFilteredPersonList().stream()
-                .filter(person -> person.getName().fullName.equalsIgnoreCase(VALID_NAME_GEORGE))
+                .filter(person -> person.getName().fullName.equalsIgnoreCase(VALID_NAME_ALICE))
                 .toList();
 
         Person firstPerson = matchingPersons.get(0);
-        Person originalPerson = new PersonBuilder(firstPerson).withTags(VALID_TAG_FRIEND).build();
-        Person editedPerson = new PersonBuilder(firstPerson).build();
+        Person originalPerson = new PersonBuilder(firstPerson).withTags(VALID_TAG_FRIENDS).build();
+        Person editedPerson = new PersonBuilder(firstPerson).withTags().build();
 
-        stubTagList.add(new Tag(VALID_TAG_FRIEND));
+        stubTagList.add(new Tag(VALID_TAG_FRIENDS));
         TagDeleteCommand tagDeleteCommand = new TagDeleteCommand(originalPerson.getName(), stubTagList);
 
         String expectedMessage = String.format(TagDeleteCommand.MESSAGE_DELETE_TAG_SUCCESS,
-                Messages.format(editedPerson));
+                Messages.tagSetToString(stubTagList), Messages.format(editedPerson));
 
         Model expectedModel = new ModelManager(new AddressBook(model.getAddressBook()), new UserPrefs());
         expectedModel.setPerson(firstPerson, editedPerson);
@@ -56,7 +56,7 @@ public class TagDeleteCommandTest {
     public void equals() {
 
         Tag tag1 = new Tag(VALID_TAG_AMY);
-        Tag tag2 = new Tag(VALID_TAG_FRIEND);
+        Tag tag2 = new Tag(VALID_TAG_FRIENDS);
         Name name = new Name(VALID_NAME_AMY);
         Set<Tag> standardTagList = new HashSet<>();
         Set<Tag> deleteTagList = new HashSet<>();
@@ -68,7 +68,7 @@ public class TagDeleteCommandTest {
 
         // same values -> returns true
         Tag stubTag1 = new Tag(VALID_TAG_AMY);
-        Tag stubTag2 = new Tag(VALID_TAG_FRIEND);
+        Tag stubTag2 = new Tag(VALID_TAG_FRIENDS);
         Name stubName = new Name(VALID_NAME_AMY);
         Set<Tag> stubTagList = new HashSet<>();
         Set<Tag> deleteStubTagList = new HashSet<>();
@@ -90,7 +90,7 @@ public class TagDeleteCommandTest {
 
         // different tag -> returns false
         Tag newStubTag1 = new Tag(VALID_TAG_BOB);
-        Tag newStubTag2 = new Tag(VALID_TAG_FRIEND);
+        Tag newStubTag2 = new Tag(VALID_TAG_FRIENDS);
         Set<Tag> newStubTagList = new HashSet<>();
         Set<Tag> newDeleteStubTagList = new HashSet<>();
         newStubTagList.add(newStubTag1);


### PR DESCRIPTION
If the person’s name isn’t in the address book, generate error message (exception).
If the tags specified don't exist for that person,
     - if there is only one tag, generate message (currently string not exception) that the specified tag doesn't exist
     - if out of a few tags, there are some that don't exist, generate message that those tags don't exist 
        and remove the tags that exist and generate delete success message for them