### PR TITLE
Add more error handling for view-wed

### DIFF
--- a/docs/UserGuide.md
+++ b/docs/UserGuide.md
@@ -276,7 +276,7 @@ Format: `view-wed KEYWORD`
 * Persons matching at least one keyword will be returned (i.e. `AND` search).
   e.g. `Alice` will not return `Alice & Bob`
 
-![filter message](images/viewWeddingMsg.png)
+![view-wed message](images/viewWeddingMsg.png)
 
 Examples:
 * `view-wed Jane Lim & Tom Koh` returns `John Doe` who is a caterer for that wedding

--- a/src/main/java/seedu/address/logic/commands/ViewWeddingCommand.java
+++ b/src/main/java/seedu/address/logic/commands/ViewWeddingCommand.java
@@ -20,10 +20,16 @@ public class ViewWeddingCommand extends Command {
     public static final String MESSAGE_USAGE = COMMAND_FUNCTION
             + "Parameters: KEYWORD"
             + "Example: " + COMMAND_WORD + " Jonus & Izzat";
-    public static final String MESSAGE_WEDDING_DOESNT_EXIST = "This wedding cannot be found."
-            + "\n"
-            + "A wedding has to be created using the command '"
+    public static final String MESSAGE_WEDDING_DOESNT_EXIST = "This wedding cannot be found.\n"
+            + "Please make sure that the wedding is created and is in the format 'NAME & NAME'.\n"
+            + "If you have not created a wedding yet, you can do so using the '"
             + AddWeddingCommand.COMMAND_WORD
+            + "' command.";
+    public static final String MESSAGE_NO_PARTICIPANTS_ADDED =
+            String.format(Messages.MESSAGE_PARTICIPANTS_LISTED_OVERVIEW, 0)
+            + "\n"
+            + "You can add a participant to this wedding using the '"
+            + TagAddCommand.COMMAND_WORD
             + "' first.";
 
     private final TagContainsKeywordsPredicate predicate;
@@ -35,11 +41,12 @@ public class ViewWeddingCommand extends Command {
     @Override
     public CommandResult execute(Model model) throws CommandException {
         requireNonNull(model);
+
         model.updateFilteredPersonList(predicate);
         int numOfParticipants = model.getFilteredPersonList().size();
 
         if (numOfParticipants == 0) {
-            throw new CommandException(String.format(MESSAGE_WEDDING_DOESNT_EXIST));
+            throw new CommandException(MESSAGE_NO_PARTICIPANTS_ADDED);
         }
 
         return new CommandResult(

--- a/src/main/java/seedu/address/logic/commands/ViewWeddingCommand.java
+++ b/src/main/java/seedu/address/logic/commands/ViewWeddingCommand.java
@@ -2,11 +2,14 @@ package seedu.address.logic.commands;
 
 import static java.util.Objects.requireNonNull;
 
+import java.util.List;
+
 import seedu.address.commons.util.ToStringBuilder;
 import seedu.address.logic.Messages;
 import seedu.address.logic.commands.exceptions.CommandException;
 import seedu.address.model.Model;
 import seedu.address.model.person.TagContainsKeywordsPredicate;
+import seedu.address.model.wedding.Wedding;
 
 /**
  * TO be updated
@@ -18,7 +21,7 @@ public class ViewWeddingCommand extends Command {
             + "the specified keywords (case-insensitive)\n";
 
     public static final String MESSAGE_USAGE = COMMAND_FUNCTION
-            + "Parameters: KEYWORD"
+            + "Parameters: KEYWORD\n"
             + "Example: " + COMMAND_WORD + " Jonus & Izzat";
     public static final String MESSAGE_WEDDING_DOESNT_EXIST = "This wedding cannot be found.\n"
             + "Please make sure that the wedding is created and is in the format 'NAME & NAME'.\n"
@@ -30,7 +33,7 @@ public class ViewWeddingCommand extends Command {
             + "\n"
             + "You can add a participant to this wedding using the '"
             + TagAddCommand.COMMAND_WORD
-            + "' first.";
+            + "' command.";
 
     private final TagContainsKeywordsPredicate predicate;
 
@@ -41,6 +44,17 @@ public class ViewWeddingCommand extends Command {
     @Override
     public CommandResult execute(Model model) throws CommandException {
         requireNonNull(model);
+
+        List<Wedding> matchingWedding = model.getFilteredWeddingList()
+                .stream()
+                .filter(wedding -> wedding.getWeddingName()
+                        .toString()
+                        .equalsIgnoreCase(predicate.getWeddingKeywords()))
+                .toList();
+
+        if (matchingWedding.isEmpty()) {
+            throw new CommandException(MESSAGE_WEDDING_DOESNT_EXIST);
+        }
 
         model.updateFilteredPersonList(predicate);
         int numOfParticipants = model.getFilteredPersonList().size();

--- a/src/main/java/seedu/address/logic/parser/ViewWeddingCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/ViewWeddingCommandParser.java
@@ -24,7 +24,7 @@ public class ViewWeddingCommandParser implements Parser<ViewWeddingCommand> {
                     String.format(MESSAGE_INVALID_COMMAND_FORMAT, ViewWeddingCommand.MESSAGE_USAGE));
         }
 
-        ParserUtil.parseWeddingName(trimmedArgs); 
+        ParserUtil.parseWeddingName(trimmedArgs);
 
         String weddingNameKeyword = trimmedArgs.toLowerCase();
 

--- a/src/main/java/seedu/address/logic/parser/ViewWeddingCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/ViewWeddingCommandParser.java
@@ -24,6 +24,8 @@ public class ViewWeddingCommandParser implements Parser<ViewWeddingCommand> {
                     String.format(MESSAGE_INVALID_COMMAND_FORMAT, ViewWeddingCommand.MESSAGE_USAGE));
         }
 
+        ParserUtil.parseWeddingName(trimmedArgs); 
+
         String weddingNameKeyword = trimmedArgs.toLowerCase();
 
         return new ViewWeddingCommand(new TagContainsKeywordsPredicate(weddingNameKeyword));

--- a/src/main/java/seedu/address/model/person/TagContainsKeywordsPredicate.java
+++ b/src/main/java/seedu/address/model/person/TagContainsKeywordsPredicate.java
@@ -17,6 +17,10 @@ public class TagContainsKeywordsPredicate implements Predicate<Person> {
         this.weddingKeywords = weddingKeywords;
     }
 
+    public String getWeddingKeywords() {
+        return this.weddingKeywords;
+    }
+
     @Override
     public boolean test(Person person) {
         List<String> tagNames = person.getTags().stream()

--- a/src/main/java/seedu/address/model/wedding/WeddingName.java
+++ b/src/main/java/seedu/address/model/wedding/WeddingName.java
@@ -9,9 +9,9 @@ import static seedu.address.commons.util.AppUtil.checkArgument;
  */
 public class WeddingName {
 
-    public static final String MESSAGE_CONSTRAINTS =
-            "Wedding Name should be 2 person names separated with &. "
-                    + "It should only contain alphanumeric characters and spaces, and it should not be blank";
+    public static final String MESSAGE_CONSTRAINTS = "Wedding Name should be 2 person names separated with &.\n"
+            + "It should only contain alphanumeric characters and spaces, and it should not be blank.\n"
+            + "Example: Charlie & Hannah";
     public static final String VALIDATION_REGEX =
             "^\\s*([\\p{Alnum}]+(?:\\s+[\\p{Alnum}]+)?)\\s*&\\s*([\\p{Alnum}]+(?:\\s+[\\p{Alnum}]+)?)\\s*$";
     public final String value;

--- a/src/test/java/seedu/address/logic/parser/ViewWeddingCommandParserTest.java
+++ b/src/test/java/seedu/address/logic/parser/ViewWeddingCommandParserTest.java
@@ -8,6 +8,7 @@ import org.junit.jupiter.api.Test;
 
 import seedu.address.logic.commands.ViewWeddingCommand;
 import seedu.address.model.person.TagContainsKeywordsPredicate;
+import seedu.address.model.wedding.WeddingName;
 
 public class ViewWeddingCommandParserTest {
 
@@ -26,5 +27,11 @@ public class ViewWeddingCommandParserTest {
         // Testing for empty arguments where the command should fail
         assertParseFailure(parser, "", String.format(MESSAGE_INVALID_COMMAND_FORMAT,
                 ViewWeddingCommand.MESSAGE_USAGE));
+    }
+
+    @Test
+    public void parse_invalidArgs_throwsParseException() {
+        // Testing for arguments with invalid format where the command should fail
+        assertParseFailure(parser, "me", WeddingName.MESSAGE_CONSTRAINTS);
     }
 }


### PR DESCRIPTION
Error handling for scenarios below:
- A non-existent wedding
- An existing wedding with no participants
- An empty string
- Incorrect format of user input (i.e. not NAME & NAME)